### PR TITLE
Fix duplicated "BEGIN" comment

### DIFF
--- a/modIncreasedMaterialsRequirement/content/scripts/game/gameplay/crafting/craftingManager.ws
+++ b/modIncreasedMaterialsRequirement/content/scripts/game/gameplay/crafting/craftingManager.ws
@@ -64,7 +64,7 @@ class W3CraftingManager
 						if(dm.GetCustomNodeAttributeValueInt(ingredients.subNodes[k], 'quantity', tmpInt))
 							// modIncreaseMaterialCost - BEGIN
 							ing.quantity = tmpInt * MCM_getMaterialMultiplier(ing.itemName, dm);
-							// modIncreaseMaterialCost - BEGIN
+							// modIncreaseMaterialCost - END
 							
 						schem.ingredients.PushBack(ing);						
 					}


### PR DESCRIPTION
It said BEGIN twice instead of BEGIN beforehand and END afterward so I thought it might just be a little clearer.